### PR TITLE
fix qrc prefix for path to store file

### DIFF
--- a/src/quickdownload.cpp
+++ b/src/quickdownload.cpp
@@ -232,6 +232,15 @@ void QuickDownload::start(QUrl url)
     emit started();
 }
 
+QString QuickDownload::remove_qrc(QString url) {
+    if (url.length()>4) {
+        // fix path to file. example url start with qrc:/home/user
+    if (url.startsWith("qrc:"))
+        url = url.mid(4); // = remove first 4 chars qrc:
+     }
+    return url;
+}
+
 void QuickDownload::start()
 {
     start(_url);

--- a/src/quickdownload.h
+++ b/src/quickdownload.h
@@ -138,6 +138,8 @@ private:
     QSaveFile *_saveFile;
     void shutdownSaveFile();
 
+    QString remove_qrc(QString url);
+
     bool _componentComplete;
 };
 


### PR DESCRIPTION
QML can be return to c++ path for file with prefix qrc
example:
`qrc:/path/to/file.txt`

This [commit](https://github.com/homdx/QuickDownload/commit/b93c98cb9b4d7aa02e33870c3bf952da260e417e) can be fix it